### PR TITLE
feat: completar fluxo seguro de JWT (cookies HttpOnly, refresh, whitelist de algoritmos)

### DIFF
--- a/src/main/java/com/cristao/inteligente/application/service/IAuthService.java
+++ b/src/main/java/com/cristao/inteligente/application/service/IAuthService.java
@@ -2,10 +2,12 @@ package com.cristao.inteligente.application.service;
 
 import com.cristao.inteligente.shared.dto.LoginRequest;
 import com.cristao.inteligente.shared.dto.LoginResponse;
-
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface IAuthService {
-    public LoginResponse login(LoginRequest req, HttpServletResponse response);
+    LoginResponse login(LoginRequest req, HttpServletResponse response);
 
+    LoginResponse refreshAccessToken(String refreshToken, HttpServletResponse response);
+
+    void logout(HttpServletResponse response);
 }

--- a/src/main/java/com/cristao/inteligente/application/service/ITokenService.java
+++ b/src/main/java/com/cristao/inteligente/application/service/ITokenService.java
@@ -1,20 +1,15 @@
 package com.cristao.inteligente.application.service;
 
-
 import com.cristao.inteligente.domain.entity.Usuario;
 
-
 public interface ITokenService {
-    public String generateToken(Usuario usuario);
+    String generateToken(Usuario usuario);
 
-    public boolean isTokenValid(String token);
-    
-    public String generateRefreshToken(String email);
-       
-    public String extractEmail(String token);
-    
-    public String extractRole(String token);
+    boolean isTokenValid(String token);
 
-  
+    String generateRefreshToken(String email, String role);
 
+    String extractEmail(String token);
+
+    String extractRole(String token);
 }

--- a/src/main/java/com/cristao/inteligente/application/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/cristao/inteligente/application/service/impl/AuthServiceImpl.java
@@ -3,57 +3,100 @@ package com.cristao.inteligente.application.service.impl;
 import com.cristao.inteligente.application.service.IAuthService;
 import com.cristao.inteligente.application.service.ITokenService;
 import com.cristao.inteligente.domain.entity.Usuario;
+import com.cristao.inteligente.domain.valueobject.Role;
+import com.cristao.inteligente.infrastructure.config.JwtProperties;
 import com.cristao.inteligente.shared.dto.LoginRequest;
 import com.cristao.inteligente.shared.dto.LoginResponse;
-
 import jakarta.servlet.http.HttpServletResponse;
-
-import com.cristao.inteligente.infrastructure.repositories.UsuarioJPARepository;
-import com.cristao.inteligente.infrastructure.repositories.jpa.entity.UsuarioEntityJPA;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 
 @Service
+@RequiredArgsConstructor
 public class AuthServiceImpl implements IAuthService {
+
+    private static final String ACCESS_TOKEN_COOKIE = "access_token";
+    private static final String REFRESH_TOKEN_COOKIE = "refresh_token";
+
     private final AuthenticationManager authenticationManager;
-
     private final ITokenService tokenService;
-    
-    private final UsuarioJPARepository usuarioRepository;
-    
-    private final PasswordEncoder passwordEncoder;
-
-
-
-    AuthServiceImpl(AuthenticationManager authenticationManager, ITokenService tokenService, UsuarioJPARepository usuarioRepository, PasswordEncoder passwordEncoder){
-        this.authenticationManager = authenticationManager;
-        this.tokenService = tokenService;
-        this.usuarioRepository = usuarioRepository;
-        this.passwordEncoder = passwordEncoder;
-    }
-
+    private final JwtProperties jwtProperties;
 
     @Override
     public LoginResponse login(LoginRequest req, HttpServletResponse response) {
-        
-    	 var usuario = usuarioRepository.findByEmail(req.getEmail())
-    	            .orElseThrow(() -> new RuntimeException("Credenciais inválidas."));
-    	
-    	UsernamePasswordAuthenticationToken usernamePassword = new UsernamePasswordAuthenticationToken(req.getEmail(), req.getPassword());
-        
-        if (!passwordEncoder.matches(req.getPassword(), usuario.getPassword())) {
-            throw new RuntimeException("Credenciais inválidas.");
-        }
-        
-        
+        var usernamePassword = new UsernamePasswordAuthenticationToken(req.getEmail(), req.getPassword());
         Authentication auth = authenticationManager.authenticate(usernamePassword);
 
-        String token = tokenService.generateToken((Usuario) auth.getPrincipal());
+        String email = auth.getName();
+        Role role = resolveRole(auth);
 
-        return new LoginResponse(token);
+        Usuario usuario = new Usuario();
+        usuario.setEmail(email);
+        usuario.setRole(role);
+
+        String accessToken = tokenService.generateToken(usuario);
+        String refreshToken = tokenService.generateRefreshToken(email, role.name());
+
+        addCookie(response, ACCESS_TOKEN_COOKIE, accessToken, jwtProperties.getAccessTokenExpirationMs());
+        addCookie(response, REFRESH_TOKEN_COOKIE, refreshToken, jwtProperties.getRefreshTokenExpirationMs());
+
+        return new LoginResponse("Login realizado com sucesso.");
+    }
+
+    @Override
+    public LoginResponse refreshAccessToken(String refreshToken, HttpServletResponse response) {
+        if (!tokenService.isTokenValid(refreshToken)) {
+            throw new RuntimeException("Refresh token inválido ou expirado.");
+        }
+
+        String email = tokenService.extractEmail(refreshToken);
+
+        Role role = Role.valueOf(tokenService.extractRole(refreshToken));
+
+        Usuario usuario = new Usuario();
+        usuario.setEmail(email);
+        usuario.setRole(role);
+
+        String newAccessToken = tokenService.generateToken(usuario);
+        String newRefreshToken = tokenService.generateRefreshToken(email, role.name());
+
+        addCookie(response, ACCESS_TOKEN_COOKIE, newAccessToken, jwtProperties.getAccessTokenExpirationMs());
+        addCookie(response, REFRESH_TOKEN_COOKIE, newRefreshToken, jwtProperties.getRefreshTokenExpirationMs());
+
+        return new LoginResponse("Token renovado com sucesso.");
+    }
+
+    @Override
+    public void logout(HttpServletResponse response) {
+        addCookie(response, ACCESS_TOKEN_COOKIE, "", 0);
+        addCookie(response, REFRESH_TOKEN_COOKIE, "", 0);
+    }
+
+    private Role resolveRole(Authentication auth) {
+        return auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .filter(authority -> authority.startsWith("ROLE_"))
+                .map(Role::valueOf)
+                .findFirst()
+                .orElse(Role.ROLE_COLABORADOR);
+    }
+
+    private void addCookie(HttpServletResponse response, String name, String value, long maxAgeInMs) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(jwtProperties.isCookieSecure())
+                .sameSite(jwtProperties.getCookieSameSite())
+                .path("/")
+                .maxAge(Duration.ofMillis(maxAgeInMs))
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
     }
 }

--- a/src/main/java/com/cristao/inteligente/application/service/impl/TokenServiceImpl.java
+++ b/src/main/java/com/cristao/inteligente/application/service/impl/TokenServiceImpl.java
@@ -4,17 +4,13 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTCreationException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
-import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.JWTVerifier;
 import com.cristao.inteligente.application.service.ITokenService;
 import com.cristao.inteligente.domain.entity.Usuario;
 import com.cristao.inteligente.infrastructure.config.JwtProperties;
-
-
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -22,120 +18,113 @@ import java.util.Date;
 import java.util.Set;
 import java.util.UUID;
 
-
 @Component
 @RequiredArgsConstructor
 public class TokenServiceImpl implements ITokenService {
 
-	
-	@Value("${api.security.token.secret}")
-    private String secret;
-    
-    
-    private Algorithm activeAlgorithm;
-    
-    private final JwtProperties jwtProperties;
-    
+    private static final String ISSUER = "cristo-god";
     private static final Set<String> ALLOWED_ALGORITHMS = Set.of("HS256", "RS256");
-    
-    
-    
-    
+
+    @Value("${api.security.token.secret:}")
+    private String legacySecret;
+
+    private final JwtProperties jwtProperties;
+
+    private Algorithm activeAlgorithm;
+
     @PostConstruct
     public void init() {
-        String alg = jwtProperties.getAlgorithm().toUpperCase();
-        if (!ALLOWED_ALGORITHMS.contains(alg)) {
-            throw new IllegalStateException(
-                "Algoritmo JWT '" + alg + "' não está na lista branca. Use: " + ALLOWED_ALGORITHMS
-            );
+        String configuredAlg = jwtProperties.getAlgorithm().toUpperCase();
+
+        if (!ALLOWED_ALGORITHMS.contains(configuredAlg)) {
+            throw new IllegalStateException("Algoritmo JWT não permitido: " + configuredAlg + ". Permitidos: " + ALLOWED_ALGORITHMS);
         }
+
+        if ("RS256".equals(configuredAlg)) {
+            throw new IllegalStateException("RS256 está na whitelist, mas requer configuração de chaves pública/privada.");
+        }
+
+        String secret = resolveSecret();
         this.activeAlgorithm = Algorithm.HMAC256(secret);
     }
-    
-    
 
     @Override
     public String generateToken(Usuario usuario) {
         try {
-            Algorithm algorithm = Algorithm.HMAC256(secret);
-
-            String token = JWT.create()
-            	    .withIssuer("cristo-god")
-            	    .withSubject(usuario.getEmail())
-            	    .withClaim("role", String.valueOf(usuario.getRole()))
-            	    .sign(activeAlgorithm);
-            
-            return token;
+            return JWT.create()
+                    .withIssuer(ISSUER)
+                    .withSubject(usuario.getEmail())
+                    .withClaim("role", String.valueOf(usuario.getRole()))
+                    .withClaim("type", "access")
+                    .withIssuedAt(new Date())
+                    .withExpiresAt(new Date(System.currentTimeMillis() + jwtProperties.getAccessTokenExpirationMs()))
+                    .sign(activeAlgorithm);
         } catch (JWTCreationException exception) {
-            throw new RuntimeException("Error while generating token", exception);
+            throw new RuntimeException("Erro ao gerar access token.", exception);
         }
     }
-    
-    
-    
-
 
     @Override
     public boolean isTokenValid(String token) {
         try {
-            Algorithm algorithm = Algorithm.HMAC256(secret);
+            String tokenAlg = JWT.decode(token).getAlgorithm();
+            if (!ALLOWED_ALGORITHMS.contains(tokenAlg)) {
+                return false;
+            }
 
-            JWT.require(algorithm)
-                .withIssuer("cristo-god")
-                .build()
-                .verify(token);
+            JWT.require(activeAlgorithm)
+                    .withIssuer(ISSUER)
+                    .build()
+                    .verify(token);
 
             return true;
-
         } catch (JWTVerificationException e) {
             return false;
         }
     }
 
+    @Override
+    public String generateRefreshToken(String email, String role) {
+        try {
+            return JWT.create()
+                    .withIssuer(ISSUER)
+                    .withSubject(email)
+                    .withJWTId(UUID.randomUUID().toString())
+                    .withClaim("role", role)
+                    .withClaim("type", "refresh")
+                    .withIssuedAt(new Date())
+                    .withExpiresAt(new Date(System.currentTimeMillis() + jwtProperties.getRefreshTokenExpirationMs()))
+                    .sign(activeAlgorithm);
+        } catch (JWTCreationException exception) {
+            throw new RuntimeException("Erro ao gerar refresh token.", exception);
+        }
+    }
 
-	@Override
-	public String generateRefreshToken(String email) {
-		 try {
-	            Algorithm algorithm = Algorithm.HMAC256(secret);
+    @Override
+    public String extractEmail(String token) {
+        return parseClaims(token).getSubject();
+    }
 
-	            String token = JWT.create()
-	            		.withIssuedAt(new Date())
-	                    .withSubject(email)
-	                    .withJWTId(UUID.randomUUID().toString())
-	                    .withExpiresAt(new Date(System.currentTimeMillis() + jwtProperties.getRefreshTokenExpirationMs()))
-	                    .sign(algorithm);
-	            
-	            return token;
-	        } catch (JWTCreationException exception) {
-	            throw new RuntimeException("Error while generating token", exception);
-	        }
-	}
+    @Override
+    public String extractRole(String token) {
+        return parseClaims(token).getClaim("role").asString();
+    }
 
+    private DecodedJWT parseClaims(String token) {
+        JWTVerifier verifier = JWT.require(activeAlgorithm)
+                .withIssuer(ISSUER)
+                .build();
 
+        return verifier.verify(token);
+    }
 
-	private DecodedJWT parseClaims(String token) {
-	    Algorithm algorithm = Algorithm.HMAC256(secret);
-
-	    JWTVerifier verifier = JWT.require(algorithm)
-	        .build();
-
-	    return verifier.verify(token);
-	}
-
-
-
-	@Override
-	public String extractEmail(String token) {
-		return parseClaims(token).getSubject();
-	}
-
-
-
-	@Override
-	public String extractRole(String token) {
-		return parseClaims(token).getClaim("role").asString();
-	}
-
-	
-
+    private String resolveSecret() {
+        if (jwtProperties.getSecret() != null && !jwtProperties.getSecret().isBlank()) {
+            return jwtProperties.getSecret();
+        }
+        if (legacySecret != null && !legacySecret.isBlank()) {
+            return legacySecret;
+        }
+        throw new IllegalStateException("Secret JWT não configurado. Defina security.jwt.secret ou api.security.token.secret.");
+    }
 }

--- a/src/main/java/com/cristao/inteligente/infrastructure/config/JwtProperties.java
+++ b/src/main/java/com/cristao/inteligente/infrastructure/config/JwtProperties.java
@@ -19,6 +19,6 @@ public class JwtProperties {
     private String secret;
     private long accessTokenExpirationMs = 900_000L;
     private long refreshTokenExpirationMs = 604_800_000L;
-    private boolean cookieSecure = false;
+    private boolean cookieSecure = true;
     private String cookieSameSite = "Strict";
 }

--- a/src/main/java/com/cristao/inteligente/infrastructure/config/SecuryConfig.java
+++ b/src/main/java/com/cristao/inteligente/infrastructure/config/SecuryConfig.java
@@ -29,6 +29,8 @@ public class SecuryConfig {
                 .authorizeHttpRequests(authz -> authz.requestMatchers(HttpMethod.POST, "/user/admin").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.POST, "/user/colaborador").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.POST, "/user/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/user/refresh").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/user/logout").permitAll()
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(filterJWT, UsernamePasswordAuthenticationFilter.class).build();

--- a/src/main/java/com/cristao/inteligente/infrastructure/rest/UsuarioController.java
+++ b/src/main/java/com/cristao/inteligente/infrastructure/rest/UsuarioController.java
@@ -1,13 +1,20 @@
 package com.cristao.inteligente.infrastructure.rest;
 
+import com.cristao.inteligente.application.service.IAuthService;
+import com.cristao.inteligente.application.service.IUsuarioService;
 import com.cristao.inteligente.shared.dto.LoginRequest;
 import com.cristao.inteligente.shared.dto.LoginResponse;
 import com.cristao.inteligente.shared.dto.UsuarioRequest;
 import com.cristao.inteligente.shared.dto.UsuarioResponse;
-import com.cristao.inteligente.application.service.IAuthService;
-import com.cristao.inteligente.application.service.IUsuarioService;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/user")
@@ -23,10 +30,23 @@ public class UsuarioController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest req) {
-        return ResponseEntity.ok(authService.login(req));
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest req, HttpServletResponse response) {
+        return ResponseEntity.ok(authService.login(req, response));
     }
 
+    @PostMapping("/refresh")
+    public ResponseEntity<LoginResponse> refresh(
+            @CookieValue(name = "refresh_token") String refreshToken,
+            HttpServletResponse response
+    ) {
+        return ResponseEntity.ok(authService.refreshAccessToken(refreshToken, response));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
+        authService.logout(response);
+        return ResponseEntity.noContent().build();
+    }
 
     @PostMapping("/admin")
     public ResponseEntity<UsuarioResponse> createAdmin(@RequestBody UsuarioRequest request) {

--- a/src/main/java/com/cristao/inteligente/infrastructure/security/FilterJWT.java
+++ b/src/main/java/com/cristao/inteligente/infrastructure/security/FilterJWT.java
@@ -6,7 +6,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -19,37 +19,35 @@ import java.util.List;
 import java.util.Optional;
 
 @Component
+@RequiredArgsConstructor
 public class FilterJWT extends OncePerRequestFilter {
-	static final String ACCESS_TOKEN_COOKIE = "access_token";
+    static final String ACCESS_TOKEN_COOKIE = "access_token";
 
-	@Autowired
-	private ITokenService tokenService;
+    private final ITokenService tokenService;
 
-	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-			throws ServletException, IOException {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
 
-		extractTokenFromCookie(request).filter(tokenService::isTokenValid).ifPresent(t -> {
-			var email = tokenService.extractEmail(t);
+        extractTokenFromCookie(request).filter(tokenService::isTokenValid).ifPresent(t -> {
+            var email = tokenService.extractEmail(t);
+            String role = tokenService.extractRole(t);
 
-			String role = tokenService.extractRole(t);
+            var auth = new UsernamePasswordAuthenticationToken(email, null,
+                    List.of(new SimpleGrantedAuthority(role)));
 
-			var auth = new UsernamePasswordAuthenticationToken(email, null,
-					List.of(new SimpleGrantedAuthority("ROLE_" + role)));
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        });
 
-			SecurityContextHolder.getContext().setAuthentication(auth);
+        filterChain.doFilter(request, response);
+    }
 
-		}
-
-		);
-
-	}
-
-	private Optional<String> extractTokenFromCookie(HttpServletRequest request) {
-		if (request.getCookies() == null)
-			return Optional.empty();
-		return Arrays.stream(request.getCookies()).filter(c -> ACCESS_TOKEN_COOKIE.equals(c.getName()))
-				.map(Cookie::getValue).findFirst();
-	}
-
+    private Optional<String> extractTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null)
+            return Optional.empty();
+        return Arrays.stream(request.getCookies())
+                .filter(c -> ACCESS_TOKEN_COOKIE.equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
 }

--- a/src/main/java/com/cristao/inteligente/shared/dto/LoginResponse.java
+++ b/src/main/java/com/cristao/inteligente/shared/dto/LoginResponse.java
@@ -1,6 +1,6 @@
 package com.cristao.inteligente.shared.dto;
 
 public record LoginResponse(
-        String token
+        String message
 ) {
 }


### PR DESCRIPTION
### Motivation
- Melhorar a segurança do fluxo de autenticação trocando tokens no corpo por cookies HttpOnly/Secure e implementando refresh token com rotação e curta duração do access token.
- Restringir algoritmos JWT a uma whitelist (`HS256`, `RS256`) para evitar uso de algoritmos inseguros.

### Description
- Finaliza `AuthServiceImpl` para autenticar, emitir `access_token` e `refresh_token` em cookies (`HttpOnly`, `Secure`, `SameSite`, `Path=/`) e adicionar endpoints de `refresh` e `logout` que rotacionam/limpam cookies; cookies usam tempos configuráveis via `JwtProperties`.
- Refatora `TokenServiceImpl` para validar whitelist de algoritmos, suportar geração de `access` e `refresh` tokens com claims (`role`, `type`, `iat`, `exp`), usar issuer fixo e resolver secret com fallback; impede `RS256` sem chave configurada.
- Atualiza contratos: `IAuthService` (`login`, `refreshAccessToken`, `logout`) e `ITokenService` (gera refresh token com `role`); `LoginResponse` agora retorna mensagem pois tokens ficam em cookie.
- Ajusta `FilterJWT` para autenticar a partir do cookie `access_token` e garantir que a cadeia de filtros continue, e atualiza `SecuryConfig` para liberar `/user/refresh` e `/user/logout`.

### Testing
- Executado `git diff --check`, sem problemas detectados (passou).
- Tentativa de executar `mvn -q test` falhou por indisponibilidade/permissão do ambiente de build (resolver dependência `spring-boot-starter-parent:3.5.3` retornou HTTP 403), portanto testes de unidade não puderam ser executados aqui.
- Execução do wrapper falhou no ambiente (`./mvnw` sem permissão e `sh mvnw` com wrapper incompleto), então não foi possível rodar a suíte de testes localmente nesta sessão.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb27bf70e08328a08328255d4aacf7)